### PR TITLE
Added support for JClic HTML5 player

### DIFF
--- a/backup/moodle2/backup_jclic_stepslib.php
+++ b/backup/moodle2/backup_jclic_stepslib.php
@@ -40,7 +40,7 @@ class backup_jclic_activity_structure_step extends backup_activity_structure_ste
         $jclic = new backup_nested_element('jclic', array('id'), array(
             'name', 'intro', 'introformat', 'url', 'skin', 'maxattempts',
             'width', 'height', 'avaluation', 'maxgrade', 'grade', 'lang',
-            'exiturl', 'timeavailable', 'timedue'));
+            'exiturl', 'timeavailable', 'timedue', 'type'));
 
         $sessions = new backup_nested_element('sessions');
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -23,6 +23,7 @@
         <FIELD NAME="exiturl" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="timeavailable" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timedue" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="type" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for jclic"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -97,7 +97,6 @@ function xmldb_jclic_upgrade($oldversion) {
 
         require_once("$CFG->dirroot/mod/jclic/db/upgradelib.php");
         // Add upgrading code from 1.9 (+ new file storage system)
-        // @TODO: test it!!!!
         jclic_migrate_files();
 
         // Add fields grade, timeavailable and timedue on table jclic
@@ -175,6 +174,16 @@ function xmldb_jclic_upgrade($oldversion) {
         unset_config('jclic_pluginjs');
 
         upgrade_mod_savepoint(true, 2015050600, 'jclic');
+    }
+
+    if ($oldversion < 2016061300) {
+
+        // Add field type on table jclic
+        $table = new xmldb_table('jclic');
+        $field = new xmldb_field('type', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '-1', 'timedue');
+        $dbman->add_field($table, $field);
+
+        upgrade_mod_savepoint(true, 2016061300, 'jclic');
     }
 
     // Final return of upgrade result (true, all went good) to Moodle.

--- a/jclic.js
+++ b/jclic.js
@@ -25,7 +25,7 @@
 
 M.mod_jclic = {};
 
-M.mod_jclic.init = function(Y, params) {
+M.mod_jclic.initApplet = function(Y, params) {
     setJarBase(params['jclic_jarbase']);
     setReporter('TCPReporter','path='+params['jclic_path']+';service='+params['jclic_service']+';user='+params['jclic_user']+';key='+params['id']+';lap='+params['jclic_lap']+';protocol='+params['jclic_protocol']);
     setSkin(params['skin']);
@@ -33,6 +33,30 @@ M.mod_jclic.init = function(Y, params) {
     setExitUrl(params['exiturl']);
     document.getElementById('jclic_applet').innerHTML = getPlugin(params['jclic_url'], params['width'], params['height']);
 };
+
+M.mod_jclic.initHTML5 = function(Y, params) {
+    var JClicOptions = {
+        reporter: 'TCPReporter',
+        path: params['jclic_path'],
+        service: params['jclic_service'],
+        user: params['jclic_user'],
+        key: params['id'],
+        lap: params['jclic_lap'],
+        protocol: params['jclic_protocol'],
+        skin: params['skin'],
+        lang: params['lang'],
+        exitUrl: params['exitUrl'],
+        width: params['width'],
+        height: params['height'],
+    };
+    if (params['jclic_ispreview']) {
+        delete JClicOptions['reporter'];
+        delete JClicOptions['path'];
+    }
+
+    JClicObject.loadProject(document.getElementById('jclic_html5'), params['jclic_url'], JClicOptions);
+};
+
 
 
 function showSessionActivities(sessionid){
@@ -42,4 +66,12 @@ function showSessionActivities(sessionid){
     } else{
         activities.className='jclic-session-activities-visible';
     }
+}
+
+function var_dump(obj) {
+ var out = '';
+ for (var i in obj) {
+ out += i + ": " + obj[i] + "\n";
+ }
+alert(out);
 }

--- a/lang/ca/jclic.php
+++ b/lang/ca/jclic.php
@@ -86,11 +86,11 @@ $string['filetype'] = 'Tipus';
 $string['filetype_help'] = 'Aquest paràmetre determina com s\'insereix l\'activitat JClic en el curs. Tenim 2 opcions:
 
 * Fitxer JClic pujat - Permet escollir un fitxer ".jclic.zip" vàlid mitjançant el selector d\'arxius.
-* URL extern - Permet especificar el URL d\'un paquet JClic. Nota: El URL ha de començar amb http(s) o www i contenir un fitxer "jclic.zip" vàlid.';
+* URL extern - Permet especificar el URL d\'un paquet JClic. Nota: El URL ha de començar amb http(s) o www i contenir un fitxer "jclic.zip" o ".jclic" vàlid.';
 $string['filetypeexternal'] = 'URL extern';
 $string['filetypelocal'] = 'Fitxer JClic pujat';
 $string['invalidjclicfile'] = 'S\'ha especificat un fitxer JClic no vàlid. El fitxer ha de tenir l\'extensió ".jclic.zip".';
-$string['invalidurl'] = 'S\'ha especificat un URL no vàlid. El URL ha de començar amb http(s) i ha d\'enllaçar a un fitxer ".jclic.zip" vàlid.';
+$string['invalidurl'] = 'S\'ha especificat un URL no vàlid. El URL ha de començar amb http(s) i ha d\'enllaçar a un fitxer ".jclic.zip" o ".jclic" vàlid.';
 $string['jclic'] = 'JClic';
 $string['jclicjarbase'] = 'URL base dels fitxers JAR';
 $string['jclicjarbase_help'] = 'Adreça web on localitzar tots els fitxers jar de JClic.';
@@ -133,3 +133,7 @@ $string['event_instances_list_viewed'] = 'S\'ha visualitzat la llista d\'instàn
 $string['results'] = 'Resultats';
 $string['report_details'] = 'Resultats detallats amb totes les sessions';
 $string['report_normal'] = 'Resum de resultats';
+
+/* Revision Moodle 3.1 */
+$string['jclicjs'] = 'URL del fitxer jclic.js';
+$string['jclicjs_help'] = 'URL on es cercarà el fitxer jclic.js necessari perquè funcioni el player no-Java.';

--- a/lang/en/jclic.php
+++ b/lang/en/jclic.php
@@ -83,11 +83,11 @@ $string['filetype'] = 'Type';
 $string['filetype_help'] = 'This setting determines how the JClic activity is included in the course. There are up to 2 options:
 
 * Uploaded JClic - Enables a valid ".jclic.zip" package to be chosen by the file picker.
-* External URL - Enables a URL to be specified. Note: The URL must start with http(s) or www and contain a valid "jclic.zip" file.';
+* External URL - Enables a URL to be specified. Note: The URL must start with http(s) or www and contain a valid "jclic.zip" or ".jclic" file.';
 $string['filetypeexternal'] = 'External URL';
 $string['filetypelocal'] = 'Uploaded JClic';
 $string['invalidjclicfile'] = 'Invalid JClic specified. It must have the ".jclic.zip" extension.';
-$string['invalidurl'] = 'Invalid URL specified. It must start with http(s) and has to be a valid ".jclic.zip" file.';
+$string['invalidurl'] = 'Invalid URL specified. It must start with http(s) and has to be a valid ".jclic.zip" or ".jclic" file.';
 $string['jclic'] = 'JClic';
 $string['jclicjarbase'] = 'Jar base';
 $string['jclicjarbase_help'] = 'Web address where to locate all the JClic jar files';
@@ -130,3 +130,7 @@ $string['event_instances_list_viewed'] = 'Instances list viewed';
 $string['results'] = 'Results';
 $string['report_details'] = 'Detailed results with all the sessions';
 $string['report_normal'] = 'Summary results';
+
+/* Revision Moodle 3.1 */
+$string['jclicjs'] = 'jclic.js file URL';
+$string['jclicjs_help'] = 'URL where to find jclic.js needed for the non-Java player..';

--- a/lang/es/jclic.php
+++ b/lang/es/jclic.php
@@ -90,11 +90,11 @@ $string['filetype'] = 'Tipo';
 $string['filetype_help'] = 'Este parámetro determina cómo se incluye el paquete JClic en el curso. Hay 2 opciones:
 
 * Fichero JClic subido - Posibilita escoger un fichero ".jclic.zip" válido mediante el selector de archivos.
-* URL externo - Posibilita especificar el URL de un paquete JClic. NOTA: El URL debe empezar con https(s) o www y contener un fichero ".jclic.zip" válido';
+* URL externo - Posibilita especificar el URL de un paquete JClic. NOTA: El URL debe empezar con https(s) o www y contener un fichero ".jclic.zip" o ".jclic" válido';
 $string['filetypeexternal'] = 'URL externo';
 $string['filetypelocal'] = 'Fichero JClic subido';
 $string['invalidjclicfile'] = 'Se ha especificado un fichero JClic no válido. El fichero debe tener la extensión ".jclic.zip".';
-$string['invalidurl'] = 'Se ha especificado un URL no válido. El URL debe empezar con http(s) y enlazar a un fichero ".jclic.zip" válido.';
+$string['invalidurl'] = 'Se ha especificado un URL no válido. El URL debe empezar con http(s) y enlazar a un fichero ".jclic.zip" o ".jclic" válido.';
 $string['jclic'] = 'JClic';
 $string['jclicjarbase'] = 'URL base de los ficheros JAR';
 $string['jclicjarbase_help'] = 'Dirección web donde localizar todos los ficheros jar de JClic.';
@@ -137,3 +137,7 @@ $string['event_instances_list_viewed'] = 'Lista instancias vista';
 $string['results'] = 'Resultados';
 $string['report_details'] = 'Resultados detallados con todas las sesiones';
 $string['report_normal'] = 'Resumen de resultados';
+
+/* Revision Moodle 3.1 */
+$string['jclicjs'] = 'URL del archivo jclic.js';
+$string['jclicjs_help'] = 'URL donde se buscará el archivo jclic.js necesario para que funcione el player no-Java.';

--- a/lib.php
+++ b/lib.php
@@ -40,6 +40,11 @@ define('JCLIC_DEFAULT_LAP', 5);
 define('JCLIC_FILE_TYPE_LOCAL', 'local');
 define('JCLIC_FILE_TYPE_EXTERNAL', 'external');
 
+// JClic activity type
+define('JCLIC_ACTIVITY_TYPE_JAVA', 0);
+define('JCLIC_ACTIVITY_TYPE_HTML5', 1);
+
+
 /** Include eventslib.php */
 require_once($CFG->libdir.'/eventslib.php');
 /** Include formslib.php */
@@ -466,7 +471,7 @@ function jclic_update_grades(stdClass $jclic, $userid = 0, $nullifnone=true) {
  */
 function jclic_get_file_areas($course, $cm, $context) {
     return array(
-        'content'      => get_string('urledit',  'jclic')
+        'package'      => get_string('urledit',  'jclic')
     );
 }
 
@@ -493,14 +498,14 @@ function jclic_get_file_info($browser, $areas, $course, $cm, $context, $filearea
 
     $fs = get_file_storage();
 
-    if ($filearea === 'content') {
+    if ($filearea === 'package') {
         $filepath = is_null($filepath) ? '/' : $filepath;
         $filename = is_null($filename) ? '.' : $filename;
 
         $urlbase = $CFG->wwwroot.'/pluginfile.php';
-        if (!$storedfile = $fs->get_file($context->id, 'mod_jclic', 'content', 0, $filepath, $filename)) {
+        if (!$storedfile = $fs->get_file($context->id, 'mod_jclic', 'package', 0, $filepath, $filename)) {
             if ($filepath === '/' and $filename === '.') {
-                $storedfile = new virtual_root_file($context->id, 'mod_jclic', 'content', 0);
+                $storedfile = new virtual_root_file($context->id, 'mod_jclic', 'package', 0);
             } else {
                 // not found
                 return null;
@@ -538,10 +543,10 @@ function jclic_pluginfile($course, $cm, $context, $filearea, array $args, $force
         return false;
     }
 
-    if ($filearea !== 'content') {
+    /*if ($filearea !== 'package') {
         // intro is handled automatically in pluginfile.php
         return false;
-    }
+    }*/
 
     array_shift($args); // ignore revision - designed to prevent caching problems only
 
@@ -552,15 +557,6 @@ function jclic_pluginfile($course, $cm, $context, $filearea, array $args, $force
         if ($file = $fs->get_file_by_hash(sha1($fullpath))) {
             break;
         }
-/*
-            $jclic = $DB->get_record('jclic', array('id'=>$cm->instance), 'id, legacyfiles', MUST_EXIST);
-            if (!$file = jcliclib_try_file_migration('/'.$relativepath, $cm->id, $cm->course, 'mod_jclic', 'content', 0)) {
-                return false;
-            }
-            // file migrate - update flag
-            $resource->legacyfileslast = time();
-            $DB->update_record('resource', $resource);
- */
     } while (false);
 
     // finally send the file

--- a/mod_form.php
+++ b/mod_form.php
@@ -60,8 +60,12 @@ class mod_jclic_mod_form extends moodleform_mod {
         $mform->addRule('name', null, 'required', null, 'client');
         $mform->addRule('name', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
 
-        // Adding the standard "intro" and "introformat" fields
-        $this->standard_intro_elements();
+        // Summary
+        if (method_exists($this, 'standard_intro_elements')) {
+            $this->standard_intro_elements();
+        } else {
+            $this->add_intro_editor();
+        }
 
         // -------------------------------------------------------------------------------
         $mform->addElement('header', 'timing', get_string('timing', 'jclic'));
@@ -138,7 +142,12 @@ class mod_jclic_mod_form extends moodleform_mod {
     function data_preprocessing(&$default_values) {
         if ($this->current->instance) {
             $draftitemid = file_get_submitted_draft_itemid('jclicfile');
-            file_prepare_draft_area($draftitemid, $this->context->id, 'mod_jclic', 'content', 0, jclic::get_filemanager_options());
+            if ($draftitemid == 0 && !empty($this->current->url)) {
+                $filearea = jclic_get_filearea($this->current->url);
+            } else {
+                $filearea = jclic_get_filearea($draftitemid);
+            }
+            file_prepare_draft_area($draftitemid, $this->context->id, 'mod_jclic', $filearea, 0, jclic::get_filemanager_options());
             $default_values['jclicfile'] = $draftitemid;
         }
     }

--- a/settings.php
+++ b/settings.php
@@ -36,5 +36,8 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configtext('jclic/pluginjs', get_string('pluginjs', 'jclic'),
                        get_string('pluginjs_help', 'jclic'), 'https://clic.xtec.cat/dist/jclic/jclicplugin.js', PARAM_TEXT));
+
+    $settings->add(new admin_setting_configtext('jclic/jclicjs', get_string('jclicjs', 'jclic'),
+                       get_string('jclicjs_help', 'jclic'), 'https://clic.xtec.cat/dist/jclic.js/jclic.min.js', PARAM_URL, 60));
 }
 

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2016052000;      // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2016061300;      // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2015111600;      // Requires this Moodle version (2.7)
 $plugin->cron      = 0;               // Period for cron to check this module (secs)
 $plugin->component = 'mod_jclic';     // To check on upgrade, that module sits in correct place

--- a/view.php
+++ b/view.php
@@ -86,6 +86,6 @@ echo $OUTPUT->header();
 echo $OUTPUT->heading($jclic->name);
 
 jclic_view_intro($jclic, $cm);
-jclic_view_applet($jclic, $context, $ispreview);
+jclic_view_activity($jclic, $context, $ispreview);
 
 echo $OUTPUT->footer();


### PR DESCRIPTION
La versió nova del mòdul de JClic admet, a banda dels fitxers .jclic.zip, les activitats següents

- Fitxer project.json (només si el contingut és un URL extern). Per exemple, https://clic.xtec.cat/projects/guixanet/project.json
- Extensió .jclic (només si el contingut és un URL extern). Per exemple, https://clic.xtec.cat/projects/guixanet/jclic.js/guixanet.jclic
- Extensió .scorm.zip (vàlid tant per fitxers com per URL). Per exemple, https://clic.xtec.cat/temp/bombers.scorm.zip o fitxer bombers.scorm.zip adjunt. En cas que al Moodle es pugi un fitxer .scorm.zip, el Moodle internament el descomprimeix i li passa al player el fitxer .project.json inclòs. Si el fitxer no conté cap .project.json, busca si conté algun xxxxx.jclic; si el troba, és aquest el fitxer que li passa al player; en cas contrari, es mostra error.