### PR TITLE
Wip redmine 4643

### DIFF
--- a/report.php
+++ b/report.php
@@ -241,12 +241,19 @@ if (!empty($users)) {
             $rowclass = ($numsessions > 0) ? 'summary-row' : "";
             $table->add_data($row, $rowclass);
         }
+        $table->pagesize($perpage, $countusers);
+        $table->print_html();  // Print the whole table
+        if (!$countusers) {
+            echo $OUTPUT->notification(get_string('msg_nosessions', 'jclic'), 'notifymessage');
+        }
+        /*
         if ($countusers) {
             $table->pagesize($perpage, $countusers);
             $table->print_html();  // Print the whole table
         } else {
             echo $OUTPUT->notification(get_string('msg_nosessions', 'jclic'), 'notifymessage');
         }
+        */
     }
 } else {
     echo $OUTPUT->notification(get_string('msg_nosessions', 'jclic'), 'notifymessage');


### PR DESCRIPTION
Al fer cerca donava error de sessió (jclic) si no trobava alumnes. També ocultaba el cercador. Ara continúa mostrant el cercador amb el missatge.